### PR TITLE
Add CLI transcription script and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # whisper-transcriber
+
 Script em Python para transcrever áudios e vídeos usando o modelo Whisper, com guia passo a passo para configuração e uso no Windows.
+
+## Requisitos
+
+- Python 3.9 ou superior.
+- Dependências instaladas com `pip install -r requirements.txt` ou diretamente com `pip install openai-whisper`. O pacote `ffmpeg` precisa estar disponível no sistema para que o Whisper processe os formatos de áudio e vídeo suportados.
+
+## Uso
+
+1. Salve o arquivo de áudio ou vídeo em um dos formatos suportados (`.mp3`, `.mp4`, `.m4a`, `.wav`, `.flac`, `.ogg`, `.webm`, `.wma`, `.aac`, `.mov`, `.mkv`).
+2. Execute o script `transcrever.py`, informando o caminho do arquivo a ser processado:
+
+   ```bash
+   python transcrever.py /caminho/para/o/arquivo.mp3
+   ```
+
+   Opcionalmente, você pode indicar um modelo específico do Whisper com a flag `--modelo` (por exemplo, `tiny`, `small`, `medium`, `large`):
+
+   ```bash
+   python transcrever.py /caminho/para/o/arquivo.mp4 --modelo small
+   ```
+
+3. O script valida o caminho informado, verifica a extensão do arquivo e, em seguida, carrega o modelo com `whisper.load_model` para executar `transcribe`. A transcrição é salva em um arquivo `.txt` com o mesmo nome do arquivo original, codificado em UTF-8.
+
+Caso ocorra algum erro (arquivo inexistente, extensão não suportada etc.), o script exibirá uma mensagem explicando o problema.

--- a/transcrever.py
+++ b/transcrever.py
@@ -1,0 +1,88 @@
+"""Script de linha de comando para transcrever áudios e vídeos com Whisper."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import whisper
+
+
+EXTENSOES_SUPORTADAS: set[str] = {
+    ".mp3",
+    ".mp4",
+    ".m4a",
+    ".wav",
+    ".flac",
+    ".ogg",
+    ".webm",
+    ".wma",
+    ".aac",
+    ".mov",
+    ".mkv",
+}
+
+
+def analisar_argumentos(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Transcreve arquivos de áudio ou vídeo usando o modelo Whisper e gera "
+            "um arquivo .txt com a transcrição."
+        )
+    )
+    parser.add_argument(
+        "arquivo",
+        help="Caminho para o arquivo de áudio ou vídeo a ser transcrito.",
+    )
+    parser.add_argument(
+        "-m",
+        "--modelo",
+        default="base",
+        help="Nome do modelo Whisper a ser carregado (padrão: base).",
+    )
+    return parser.parse_args(list(argv))
+
+
+def validar_caminho(entrada: Path) -> None:
+    if not entrada.exists():
+        raise FileNotFoundError(f"Arquivo não encontrado: {entrada}")
+    if not entrada.is_file():
+        raise ValueError(f"O caminho precisa apontar para um arquivo: {entrada}")
+    if entrada.suffix.lower() not in EXTENSOES_SUPORTADAS:
+        extensoes = ", ".join(sorted(EXTENSOES_SUPORTADAS))
+        raise ValueError(
+            "Extensão de arquivo não suportada. Use um dos formatos: " f"{extensoes}."
+        )
+
+
+def transcrever_arquivo(caminho: Path, modelo: str) -> Path:
+    validar_caminho(caminho)
+    modelo_carregado = whisper.load_model(modelo)
+    resultado = modelo_carregado.transcribe(str(caminho))
+    texto_transcrito = resultado.get("text", "").strip()
+
+    arquivo_saida = caminho.with_suffix(".txt")
+    with open(arquivo_saida, "w", encoding="utf-8") as saida:
+        saida.write(texto_transcrito)
+
+    return arquivo_saida
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = analisar_argumentos(sys.argv[1:] if argv is None else argv)
+    caminho = Path(args.arquivo).expanduser().resolve()
+
+    try:
+        arquivo_saida = transcrever_arquivo(caminho, args.modelo)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Erro: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Transcrição concluída. Arquivo salvo em: {arquivo_saida}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add the `transcrever.py` command-line script that validates inputs before using Whisper to transcribe audio or video files
- ensure the transcription output is saved as a UTF-8 encoded `.txt` file alongside the source media
- document requirements and usage instructions for the new script in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df22ed8c3483308e7d5dd5b2ab2d75