### PR TITLE
Add Whisper transcription module with CLI and tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_transcrever.py
+++ b/tests/test_transcrever.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import transcrever
+
+
+class DummyModel:
+    def __init__(self, texto: str):
+        self.texto = texto
+        self.caminhos_recebidos: list[str] = []
+
+    def transcribe(self, caminho: str):
+        self.caminhos_recebidos.append(caminho)
+        return {"text": self.texto}
+
+
+def configurar_modelo(monkeypatch: pytest.MonkeyPatch, texto: str) -> DummyModel:
+    modelo = DummyModel(texto)
+
+    def carregar_modelo(_nome: str) -> DummyModel:
+        return modelo
+
+    monkeypatch.setattr(transcrever.whisper, "load_model", carregar_modelo)
+    return modelo
+
+
+def test_transcrever_arquivo_cria_txt_utf8(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    arquivo = tmp_path / "audio.mp3"
+    arquivo.write_bytes(b"dados ficticios")
+
+    modelo = configurar_modelo(monkeypatch, "conteúdo")
+
+    saida = transcrever.transcrever_arquivo(arquivo, modelo="base")
+
+    assert saida.suffix == ".txt"
+    assert saida.exists()
+    assert modelo.caminhos_recebidos == [str(arquivo.resolve())]
+    assert saida.read_text(encoding="utf-8") == "conteúdo"
+
+
+def test_validar_caminho_arquivo_inexistente(tmp_path: Path):
+    caminho = tmp_path / "inexistente.mp3"
+
+    with pytest.raises(FileNotFoundError) as erro:
+        transcrever.validar_caminho(caminho)
+
+    assert "não encontrado" in str(erro.value)
+
+
+def test_validar_caminho_diretorio(tmp_path: Path):
+    with pytest.raises(IsADirectoryError) as erro:
+        transcrever.validar_caminho(tmp_path)
+
+    assert "é um diretório" in str(erro.value)
+
+
+def test_validar_caminho_extensao_nao_suportada(tmp_path: Path):
+    arquivo = tmp_path / "arquivo.txt"
+    arquivo.write_text("conteudo")
+
+    with pytest.raises(ValueError) as erro:
+        transcrever.validar_caminho(arquivo)
+
+    assert "Extensão não suportada" in str(erro.value)
+
+
+def test_main_sucesso(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    arquivo = tmp_path / "audio.wav"
+    arquivo.write_bytes(b"binario")
+
+    configurar_modelo(monkeypatch, "conteúdo")
+
+    codigo = transcrever.main([str(arquivo)])
+
+    captura = capsys.readouterr()
+    esperado = arquivo.with_suffix(".txt")
+
+    assert codigo == 0
+    assert esperado.exists()
+    assert "Transcrição salva em:" in captura.out
+    assert str(esperado) in captura.out
+    assert captura.err == ""
+    assert esperado.read_text(encoding="utf-8") == "conteúdo"
+
+
+@pytest.mark.parametrize(
+    "caminho",
+    [
+        "arquivo-inexistente.mp3",
+        "arquivo.mp3/",
+    ],
+)
+def test_main_erros(tmp_path: Path, capsys: pytest.CaptureFixture[str], caminho: str):
+    if caminho.endswith("/"):
+        destino = tmp_path / "pasta"
+        destino.mkdir()
+        alvo = destino
+    else:
+        alvo = tmp_path / caminho
+
+    codigo = transcrever.main([str(alvo)])
+    captura = capsys.readouterr()
+
+    assert codigo == 1
+    assert captura.out == ""
+    assert "Erro:" in captura.err

--- a/transcrever.py
+++ b/transcrever.py
@@ -1,0 +1,102 @@
+"""Ferramentas para transcrever arquivos de áudio/vídeo usando Whisper."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Iterable
+
+import whisper
+
+EXTENSOES_SUPORTADAS: frozenset[str] = frozenset(
+    {".mp3", ".mp4", ".m4a", ".wav", ".ogg", ".flac", ".wma", ".aac"}
+)
+
+
+def validar_caminho(caminho: str | Path) -> Path:
+    """Valida o caminho para o arquivo que será transcrito.
+
+    Args:
+        caminho: Caminho para o arquivo de áudio ou vídeo.
+
+    Returns:
+        Um objeto :class:`Path` pronto para uso.
+
+    Raises:
+        FileNotFoundError: Se o caminho não existir.
+        IsADirectoryError: Se o caminho apontar para um diretório.
+        ValueError: Se a extensão do arquivo não estiver na lista suportada.
+    """
+
+    caminho_path = Path(caminho).expanduser().resolve()
+    if not caminho_path.exists():
+        raise FileNotFoundError(f"Arquivo '{caminho_path}' não encontrado.")
+    if caminho_path.is_dir():
+        raise IsADirectoryError(f"O caminho '{caminho_path}' é um diretório.")
+
+    if caminho_path.suffix.lower() not in EXTENSOES_SUPORTADAS:
+        extensoes_formatadas = ", ".join(sorted(EXTENSOES_SUPORTADAS))
+        raise ValueError(
+            "Extensão não suportada. Use arquivos com as seguintes extensões: "
+            f"{extensoes_formatadas}."
+        )
+
+    return caminho_path
+
+
+def transcrever_arquivo(caminho: str | Path, modelo: str = "base") -> Path:
+    """Transcreve o arquivo indicado e salva um `.txt` com o resultado.
+
+    Args:
+        caminho: Caminho para o arquivo de áudio/vídeo.
+        modelo: Nome do modelo Whisper a ser utilizado.
+
+    Returns:
+        Caminho para o arquivo ``.txt`` gerado com a transcrição.
+    """
+
+    arquivo = validar_caminho(caminho)
+    modelo_whisper = whisper.load_model(modelo)
+    resultado = modelo_whisper.transcribe(str(arquivo))
+    texto = resultado.get("text", "")
+
+    destino = arquivo.with_suffix(".txt")
+    destino.write_text(texto, encoding="utf-8")
+    return destino
+
+
+def _criar_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Transcreve arquivos de áudio e vídeo utilizando Whisper."
+    )
+    parser.add_argument(
+        "arquivo",
+        help="Caminho para o arquivo de áudio ou vídeo a ser transcrito.",
+    )
+    parser.add_argument(
+        "-m",
+        "--modelo",
+        default="base",
+        help="Modelo Whisper a ser utilizado (padrão: base).",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Ponto de entrada principal do script."""
+
+    parser = _criar_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        arquivo_saida = transcrever_arquivo(args.arquivo, args.modelo)
+    except Exception as exc:  # pragma: no cover - mantido simples para CLI
+        print(f"Erro: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Transcrição salva em: {arquivo_saida}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - fluxo de execução direto
+    sys.exit(main())

--- a/whisper.py
+++ b/whisper.py
@@ -1,0 +1,14 @@
+"""Implementação simplificada para permitir testes sem a dependência real."""
+
+from __future__ import annotations
+
+
+class WhisperModel:
+    def transcribe(self, _caminho: str):
+        raise NotImplementedError("Substitua WhisperModel nas execuções de teste.")
+
+
+def load_model(_modelo: str) -> WhisperModel:  # pragma: no cover - apenas placeholder
+    raise RuntimeError(
+        "O pacote whisper real não está instalado. Utilize monkeypatch nos testes."
+    )


### PR DESCRIPTION
## Summary
- implement a Whisper-based transcription module with path validation and CLI handling
- provide a lightweight local stub for the `whisper` package to allow testing without the real dependency
- add pytest coverage for transcription output, validation errors, and CLI success and failure scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2528b8788330a8e299b50b7bc9c6